### PR TITLE
Fixes ESP Generation from Archlinux 2022.07+

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,9 +64,9 @@ fi
 echo "Creating new partition scheme on $DISK."
 parted -s "$DISK" \
     mklabel gpt \
-    mkpart ESP fat32 1MiB 101MiB \
+    mkpart ESP fat32 1MiB 128MiB \
     set 1 esp on \
-    mkpart cryptroot 101MiB 100% \
+    mkpart cryptroot 128MiB 100% \
 
 sleep 0.1
 ESP="/dev/$(lsblk $DISK -o NAME,PARTLABEL | grep ESP| cut -d " " -f1 | cut -c7-)"
@@ -78,7 +78,7 @@ partprobe "$DISK"
 
 # Formatting the ESP as FAT32.
 echo "Formatting the EFI Partition as FAT32."
-mkfs.fat -F 32 $ESP &>/dev/null
+mkfs.fat -F 32 -s 2 $ESP &>/dev/null
 
 # Creating a LUKS Container for the root partition.
 echo "Creating LUKS Container for the root partition."


### PR DESCRIPTION
Fixes ESP filesystem generation on Live Archlinux ISOs from July 2022 to September (fixes both "Sector Not Allocated" error from mkfs.fat in both QEMU (via quickemu) and VMware Workstation and the grub-install command since the changes to grub-install introduced in the latest update.

Have had 100% successful installs since making this change.

Signed-off-by: funk-on-code <113871227+funk-on-code@users.noreply.github.com>