### PR TITLE
Auditd should point to chroot, not live install.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -396,7 +396,7 @@ arch-chroot /mnt chown -R $username:$username /home/${username}/.config
 sed -i 's/# %wheel ALL=(ALL) ALL/%wheel ALL=(ALL) ALL/g' /mnt/etc/sudoers
 
 # Change audit logging group
-echo "log_group = audit" >> /etc/audit/auditd.conf
+echo "log_group = audit" >> /mnt/etc/audit/auditd.conf
 
 # Enabling audit service.
 systemctl enable auditd --root=/mnt &>/dev/null


### PR DESCRIPTION
Auditd fails to start on ArchLinux 2022.10 because the auditd.conf file does not exist in the chroot after install.

Signed-off-by: funk-on-code <113871227+funk-on-code@users.noreply.github.com>