### PR TITLE
Fix sed command for sudo access

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -393,7 +393,7 @@ arch-chroot /mnt chown -R $username:$username /home/${username}/.config
 [ -n "$username" ] && echo "Setting user password for ${username}." && arch-chroot /mnt /bin/passwd "$username"
 
 # Giving wheel user sudo access.
-sed -i 's/# %wheel ALL=(ALL) ALL/%wheel ALL=(ALL) ALL/g' /mnt/etc/sudoers
+sed -i 's/# \(%wheel ALL=(ALL\(:ALL\|\)) ALL\)/\1/g' /mnt/etc/sudoers
 
 # Change audit logging group
 echo "log_group = audit" >> /mnt/etc/audit/auditd.conf


### PR DESCRIPTION
The current version of archiso set up the sudoers file with the following line:
```
# %wheel ALL=(ALL:ALL) ALL
```
Which isn't matched by the current regexp so I modified it to match both case