### PR TITLE
Add less and man to default package lists.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -327,7 +327,7 @@ output 'Installing the base system (it may take a while).'
 output "You may see an error when mkinitcpio tries to generate a new initramfs."
 output "It is okay. The script will regenerate the initramfs later in the installation process."
 
-pacstrap /mnt apparmor base chrony efibootmgr firewalld grub grub-btrfs inotify-tools linux-firmware linux-hardened linux-lts nano reflector sbctl snapper sudo zram-generator
+pacstrap /mnt apparmor base chrony efibootmgr firewalld grub grub-btrfs inotify-tools less linux-firmware linux-hardened linux-lts man nano reflector sbctl snapper sudo zram-generator
 
 if [ "${virtualization}" = 'none' ]; then
     CPU=$(grep vendor_id /proc/cpuinfo)


### PR DESCRIPTION
Re-add two useful packages back into the default list.

I don't want to re-order the default list too much, minimal is best and alterations are what forks are for, but not having a man page reader and having no networking (am testing why systemd-networking seems broken on server ATM) seems counter-intuitive on a server installation at least. 